### PR TITLE
Fix broken dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
-var gutil = require('gulp-util');
 var through = require('through2');
 var gs = require("glob-stream");
 var Q = require('kew');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "fs": "0.0.2",
     "glob-stream": "^5.3.1",
-    "gutil": "^1.6.4",
     "kew": "^0.7.0",
     "path": "^0.12.7",
     "through2": "^2.0.0"


### PR DESCRIPTION
The index file requires `gulp-util`, but `package.json` declares `gutil` as a dependency.

`index.js` doesn't use either `gulp-util` or `gutil`. This pull request removes all unused references of `gulp-utils` and `gutil` from the package.
