### PR TITLE
Remove incorrect dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "fs": "0.0.2",
     "glob-stream": "^5.3.1",
     "kew": "^0.7.0",
-    "path": "^0.12.7",
     "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
`fs` and `path` dependencies are incorrect and misleading. `nodejs` by default provides `fs` and `path` modules. The actual code inside these dependencies is incorrect/out-of-sync and not used when `require`d.
